### PR TITLE
fix: changed next_u32 to u64 to fix get_unchecked index slice bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 authors = ["Justin Gullingsrud <justinrocks@gmail.com>"]
 
 [dependencies]
-rand_core = "0.3.0"
+rand = "0.8.5"
+rand_core = "0.6.4"
 
 [dev-dependencies]
 

--- a/src/bin/random123.rs
+++ b/src/bin/random123.rs
@@ -8,7 +8,7 @@ use rand_core::{SeedableRng, RngCore};
 fn main() {
     let mut rng = ThreeFry2x64Rng::seed_from_u64(0);
     loop {
-        println!("{}", rng.next_u32());
+        println!("{}", rng.next_u64());
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 extern crate rand_core;
 extern crate core;
-
+extern crate rand;
 pub mod threefry;
 pub mod philox;
 pub mod rng;

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -1,9 +1,13 @@
 use core::fmt;
-use rand_core::{RngCore, SeedableRng, Error};
+use rand_core::{RngCore, SeedableRng, Error as RandCoreError};
 use rand_core::block::{BlockRngCore, BlockRng, BlockRng64};
 
 use super::philox::{Philox2x32,  Philox2x64,  Philox4x32,  Philox4x64};
 use super::threefry::{ThreeFry2x64};
+
+//
+extern crate rand;
+//
 
 macro_rules! impl_rng {
     ($t: ty, $n:expr, $i: ty, $b: expr, $block: ident, $rng: path) => {
@@ -38,7 +42,7 @@ macro_rules! impl_rng {
                 $rng($block::<$t>::from_seed(seed))
             }
 
-            fn from_rng<R: RngCore>(rng: R) -> Result<Self, Error> {
+            fn from_rng<R: RngCore>(rng: R) -> Result<Self, RandCoreError> {
                 $block::<$t>::from_rng(rng).map($rng)
             }
         }
@@ -66,7 +70,7 @@ macro_rules! impl_rng {
             }
         
             #[inline]
-            fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
+            fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), RandCoreError> {
                 self.0.try_fill_bytes(dest)
             }
         }
@@ -90,6 +94,33 @@ impl_rng!(Philox4x32, 4, u32, 8, BlockRng,   Philox4x32Rng);
 impl_rng!(Philox4x64, 4, u64,16, BlockRng64, Philox4x64Rng);
 
 impl_rng!(ThreeFry2x64, 2, u64,16, BlockRng64, ThreeFry2x64Rng);
+
+//
+// impl rand::RngCore for ThreeFry2x64Rng {
+//     #[inline]
+//     fn next_u32(&mut self) -> u32 {
+//         self.0.next_u32()
+//     }
+
+//     #[inline]
+//     fn next_u64(&mut self) -> u64 {
+//         self.0.next_u64()
+//     }
+
+//     #[inline]
+//     fn fill_bytes(&mut self, dest: &mut [u8]) {
+//         self.0.fill_bytes(dest)
+//     }
+
+//     #[inline]
+//     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
+//         self.0.try_fill_bytes(dest)
+//     }
+// }
+
+
+// impl rand::Rng for ThreeFry2x64Rng {}
+//
 
 #[cfg(test)]
 mod tests {

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -3,7 +3,7 @@ use rand_core::{RngCore, SeedableRng, Error as RandCoreError};
 use rand_core::block::{BlockRngCore, BlockRng, BlockRng64};
 
 use super::philox::{Philox2x32,  Philox2x64,  Philox4x32,  Philox4x64};
-use super::threefry::{ThreeFry2x64};
+use super::threefry::ThreeFry2x64;
 
 //
 extern crate rand;

--- a/src/threefry.rs
+++ b/src/threefry.rs
@@ -1,3 +1,4 @@
+// <threefry.rs>
 use rand_core::le;
 
 pub type Array2x64 = [u64; 2];
@@ -141,3 +142,4 @@ mod tests {
 //    }
 }
 
+// <threefry.rs>


### PR DESCRIPTION
In ``random123.rs`` main function, `rng.next_u32` was called which gives the error `unsafe precondition(s) violated: slice::get_unchecked requires that the index is within the slice` probably because we seeded with u64. Fixed it by just changing it to `rng.next_u64` 